### PR TITLE
Style site with brochure color palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
+/* Color palette derived from JGD Residency brochure */
 body {
   margin: 0;
-  font-family: 'Inter', sans-serif;
-  background-color: #0a0a0f;
-  color: #f5f5f5;
+  font-family: 'Roboto', sans-serif;
+  background-color: #faf9f5;
+  color: #222;
 }
 .nav {
-  background: #111;
+  background: #183153;
   padding: 1rem;
   position: sticky;
   top: 0;
@@ -19,8 +20,8 @@ body {
   align-items: center;
 }
 .logo {
-  font-weight: 800;
-  color: #cc3366;
+  font-weight: 700;
+  color: #d86b27;
 }
 .nav-links {
   list-style: none;
@@ -28,8 +29,13 @@ body {
   gap: 1.5rem;
 }
 .nav-links li a {
-  color: #eee;
+  color: #f0f0f0;
   text-decoration: none;
+  transition: color 0.2s ease-in-out;
+}
+
+.nav-links li a:hover {
+  color: #ffd166;
 }
 .hero {
   background-image: url('hero.jpg');
@@ -57,7 +63,7 @@ body {
 }
 .hero-text p {
   font-size: 1.2rem;
-  color: #ccc;
+  color: #555;
 }
 .section {
   padding: 4rem 2rem;
@@ -65,10 +71,10 @@ body {
   margin: 0 auto;
 }
 .alt {
-  background: #15151c;
+  background: #eaeaea;
 }
 h2 {
-  color: #ff9d1b;
+  color: #d86b27;
 }
 .grid {
   display: grid;
@@ -85,11 +91,21 @@ h2 {
 .gallery img {
   width: 100%;
   border-radius: 12px;
-  border: 1px solid #333;
+  border: 1px solid #ccc;
 }
 .footer {
   text-align: center;
   padding: 2rem;
-  background: #0c0c0f;
-  color: #888;
+  background: #183153;
+  color: #f0f0f0;
+}
+
+@media (max-width: 600px) {
+  .hero-text h1 {
+    font-size: 2rem;
+  }
+
+  .hero-text p {
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- apply color scheme from the JGD Residency brochure across the site
- switch to Roboto font and update component accents and footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bd47e63c832c87e385c939e6044c