### PR TITLE
feat: switch to free chatbot api

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+glamourhomebuilder.online

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository contains a lightweight, static website for Glamour Home Builders showcasing their ongoing project,
 **Jai Guru Datta Residency**.
 
+Live site: https://glamourhomebuilder.online/
+
 ## Getting started
 
 To preview the site locally, open `index.html` in a web browser. All assets, including the project brochure PDF, reside
@@ -23,6 +25,10 @@ The contact section includes a lightweight chat box that can email a transcript 
    dashboard.
 
 Without these values the chat will work locally, but the "Email Conversation" button will not send any messages.
+
+### Chatbot AI
+
+The chat interface uses the free [Affiliate+ chatbot API](https://api.affiliateplus.xyz/). No API key is required, though responses may be generic. To use another model, update the endpoint in `chat.js`.
 
 ## Deployment
 

--- a/chat.js
+++ b/chat.js
@@ -1,11 +1,20 @@
+// Initialize EmailJS (replace with your EmailJS user ID)
 (function() {
-  emailjs.init('YOUR_USER_ID'); // Replace with your EmailJS user ID
+  emailjs.init('YOUR_USER_ID');
 })();
+
+// This example uses the free Affiliate+ Chatbot API
+// no API key required
 
 const chatLog = document.getElementById('chat-log');
 const chatInput = document.getElementById('chat-input');
 const clientEmail = document.getElementById('client-email');
+
+// Stores text lines for emailing
 const messages = [];
+
+// Session identifier for the free chatbot API
+const sessionId = Math.random().toString(36).substring(2);
 
 function appendMessage(text, sender = 'client') {
   const msg = document.createElement('div');
@@ -13,14 +22,35 @@ function appendMessage(text, sender = 'client') {
   msg.textContent = text;
   chatLog.appendChild(msg);
   chatLog.scrollTop = chatLog.scrollHeight;
-  messages.push(text);
+  const prefix = sender === 'client' ? 'Client: ' : 'Bot: ';
+  messages.push(prefix + text);
 }
 
-document.getElementById('chat-send').addEventListener('click', function() {
+async function fetchAIResponse(text) {
+  const params = new URLSearchParams({
+    message: text,
+    botname: 'GlamourAI',
+    ownername: 'Glamour Home Builders',
+    sessionid: sessionId
+  });
+  const response = await fetch('https://api.affiliateplus.xyz/api/chatbot?' + params.toString());
+  const data = await response.json();
+  return data.message.trim();
+}
+
+document.getElementById('chat-send').addEventListener('click', async function() {
   const text = chatInput.value.trim();
-  if (text) {
-    appendMessage(text);
-    chatInput.value = '';
+  if (!text) return;
+
+  appendMessage(text, 'client');
+  chatInput.value = '';
+
+  try {
+    const reply = await fetchAIResponse(text);
+    appendMessage(reply, 'bot');
+  } catch (err) {
+    console.error('AI response failed', err);
+    appendMessage('Sorry, I am having trouble responding right now.', 'bot');
   }
 });
 
@@ -29,9 +59,10 @@ document.getElementById('chat-email').addEventListener('click', function() {
     alert('Please enter a message before sending.');
     return;
   }
-  const conversation = messages.join('\n');
+
+  const conversationText = messages.join('\n');
   emailjs.send('YOUR_SERVICE_ID', 'YOUR_TEMPLATE_ID', {
-    conversation: conversation,
+    conversation: conversationText,
     client_email: clientEmail.value
   }).then(function() {
     alert('Conversation sent!');

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Glamour Home Builders — JGD Residency</title>
+  <link rel="canonical" href="https://glamourhomebuilder.online/" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pMSsTUMRaVeuKiwoKP1HjqCOUMIqFZRMVAbwY/jGj54jjXNpMOGepQ6Xl0RH/e+N7Gsh/QZ/HqLF6Z+z+qw1Ig==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="style.css" />
@@ -11,7 +12,7 @@
 <body>
   <nav class="nav">
     <div class="nav-container">
-      <div class="logo">Glamour Home Builders</div>
+      <div class="logo"><a href="https://glamourhomebuilder.online">Glamour Home Builders</a></div>
       <ul class="nav-links">
         <li><a href="#about">About</a></li>
         <li><a href="#specs">Specifications</a></li>

--- a/style.css
+++ b/style.css
@@ -23,6 +23,10 @@ body {
   font-weight: 700;
   color: #d86b27;
 }
+.logo a {
+  color: #d86b27;
+  text-decoration: none;
+}
 .nav-links {
   list-style: none;
   display: flex;


### PR DESCRIPTION
## Summary
- replace paid OpenAI calls with free Affiliate+ chatbot API
- document free chatbot usage in README and add canonical link for glamourhomebuilder.online
- link site logo to new glamourhomebuilder.online domain
- add CNAME file for custom domain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a350c57b70832ca761698f3cc15362