### PR TITLE
feat: render listings with react and redesign chat box

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -26,6 +26,20 @@ function appendMessage(text, sender = 'client') {
   messages.push(prefix + text);
 }
 
+function getBasicInfoResponse(text) {
+  const lower = text.toLowerCase();
+  if (lower.includes('project')) {
+    return 'Glamour Home Builders crafts luxury residences with modern amenities.';
+  }
+  if (lower.includes('contact') || lower.includes('phone') || lower.includes('email')) {
+    return 'Reach us at (555) 123-4567 or info@glamourhomebuilders.com.';
+  }
+  if (lower.includes('location') || lower.includes('where')) {
+    return 'Our showroom is located at 123 Main Street, Springfield.';
+  }
+  return null;
+}
+
 async function fetchAIResponse(text) {
   const params = new URLSearchParams({
     message: text,
@@ -44,6 +58,12 @@ document.getElementById('chat-send').addEventListener('click', async function() 
 
   appendMessage(text, 'client');
   chatInput.value = '';
+
+  const basic = getBasicInfoResponse(text);
+  if (basic) {
+    appendMessage(basic, 'bot');
+    return;
+  }
 
   try {
     const reply = await fetchAIResponse(text);
@@ -71,3 +91,13 @@ document.getElementById('chat-email').addEventListener('click', function() {
     alert('Failed to send conversation.');
   });
 });
+
+chatInput.addEventListener('keypress', function(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    document.getElementById('chat-send').click();
+  }
+});
+
+appendMessage('Welcome to Glamour Home Builders! We craft luxury residences for modern living.', 'bot');
+appendMessage('Visit us at 123 Main Street, Springfield or call (555) 123-4567.', 'bot');

--- a/index.html
+++ b/index.html
@@ -62,18 +62,7 @@
 
   <section id="listings" class="section fade-in">
     <h2>Featured Listings</h2>
-    <div class="listings">
-      <div class="property fade-in">
-        <img src="building.jpg" alt="JGD Residency exterior" />
-        <h3>JGD Residency</h3>
-        <p>Premium 2 &amp; 3 BHK homes in Hyderabad</p>
-      </div>
-      <div class="property fade-in">
-        <img src="hero.jpg" alt="Spacious interiors" />
-        <h3>Modern Interiors</h3>
-        <p>Thoughtfully designed living spaces</p>
-      </div>
-    </div>
+    <div id="listings-root"></div>
   </section>
 
   <section id="location" class="section alt fade-in">
@@ -99,8 +88,9 @@
   <section id="contact" class="section fade-in">
     <h2>Chat With Us</h2>
     <div class="chat-box">
+      <div class="chat-header">GlamourAI</div>
       <div id="chat-log" class="chat-log"></div>
-      <input type="text" id="chat-input" placeholder="Type your message..." />
+      <input type="text" id="chat-input" placeholder="Ask about our project, contact or location..." />
       <div class="chat-actions">
         <button id="chat-send">Send</button>
         <button id="chat-email">Email Conversation</button>
@@ -116,6 +106,9 @@
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
   <script src="https://cdn.jsdelivr.net/npm/emailjs-com@3/dist/email.min.js"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="listings.js"></script>
   <script src="chat.js"></script>
   <script src="app.js"></script>
   </body>

--- a/listings.js
+++ b/listings.js
@@ -1,0 +1,27 @@
+const listings = [
+  { img: 'building.jpg', title: 'JGD Residency', desc: 'Premium 2 & 3 BHK homes in Hyderabad' },
+  { img: 'hero.jpg', title: 'Modern Interiors', desc: 'Thoughtfully designed living spaces' }
+];
+
+function Listing(props) {
+  return React.createElement(
+    'div',
+    { className: 'property fade-in' },
+    React.createElement('img', { src: props.img, alt: props.title }),
+    React.createElement('h3', null, props.title),
+    React.createElement('p', null, props.desc)
+  );
+}
+
+function Listings() {
+  return React.createElement(
+    'div',
+    { className: 'listings' },
+    listings.map((item, i) => React.createElement(Listing, { key: i, ...item }))
+  );
+}
+
+ReactDOM.render(
+  React.createElement(Listings, null),
+  document.getElementById('listings-root')
+);

--- a/style.css
+++ b/style.css
@@ -123,22 +123,41 @@ h2 {
   .chat-box {
     max-width: 600px;
     margin: 0 auto;
-    border: 1px solid #ccc;
+    border: 2px solid #0ea5e9;
     border-radius: 8px;
     padding: 1rem;
-    background: #fff;
+    background: #f0f9ff;
+  }
+
+  .chat-header {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+    color: #0ea5e9;
   }
 
   .chat-log {
     height: 200px;
     overflow-y: auto;
-    border: 1px solid #eee;
+    border: 1px solid #bae6fd;
+    background: #fff;
     padding: 0.5rem;
     margin-bottom: 0.5rem;
   }
 
-  .chat-message {
+  .chat-message.bot {
+    background: #e0f2fe;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
     margin-bottom: 0.25rem;
+  }
+
+  .chat-message.client {
+    background: #d1fae5;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    margin-bottom: 0.25rem;
+    text-align: right;
   }
 
   #chat-input,
@@ -158,7 +177,7 @@ h2 {
   .chat-actions button {
     flex: 1;
     padding: 0.5rem;
-    background: #183153;
+    background: #0ea5e9;
     color: #fff;
     border: none;
     border-radius: 4px;
@@ -166,7 +185,7 @@ h2 {
   }
 
   .chat-actions button:hover {
-    background: #d86b27;
+    background: #0284c7;
   }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- render "Featured Listings" with a lightweight React component
- wire React via CDN
- allow sending chat messages with the Enter key
- redesign chat box with new colors and a header
- preload bot with project, contact, and location info and handle those questions directly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37448f2a0832ca49974c63106b8e6