### PR TITLE
Fix Floor Plan dropdown to render embedded PDF with responsive viewer and fallback

### DIFF
--- a/floorplan.js
+++ b/floorplan.js
@@ -29,17 +29,15 @@
           {
             data: 'floorplan/JGD-Floorplan.pdf',
             type: 'application/pdf',
-            className: 'floorplan-frame'
+            width: '100%',
+            height: '600px',
+            className: 'floorplan-frame',
+            'aria-label': 'Floor Plan PDF Viewer'
           },
           React.createElement(
             'p',
             { className: 'pdf-message' },
-            'PDF failed to load. ',
-            React.createElement(
-              'a',
-              { href: 'floorplan/JGD-Floorplan.pdf' },
-              'Download Floor Plan (PDF)'
-            )
+            'Unable to display the floor plan. Please use the link below to download the PDF.'
           )
         ),
         React.createElement(

--- a/gallery-floorplan.css
+++ b/gallery-floorplan.css
@@ -84,13 +84,23 @@
 /* Floor plan styles */
 .floorplan-wrapper {
   margin-top: 1rem;
+  text-align: center;
 }
 
 .floorplan-frame {
   width: 100%;
-  min-height: 500px;
+  height: 600px;
   border: 1px solid #ccc;
   border-radius: 8px;
+  display: block;
+  margin: 0 auto;
+}
+
+@media (max-width: 640px) {
+  .floorplan-frame {
+    height: 400px;
+    max-height: 80vh;
+  }
 }
 
 .download-link {


### PR DESCRIPTION
## Summary
- Embed floor plan PDF with responsive `<object>` viewer and accessibility label
- Style PDF viewer for desktop and mobile with clean centered layout
- Maintain download link and fallback message when PDF fails to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fbb1246c832c9c70449f8130fd24