### PR TITLE
Fix: true-collapsed Gallery and inline Floor Plan PDF viewer with accessibility + fallbacks

### DIFF
--- a/floorplan.js
+++ b/floorplan.js
@@ -1,8 +1,20 @@
 (function () {
-  const { useState } = React;
+  const { useState, useEffect } = React;
 
   function FloorPlan() {
     const [open, setOpen] = useState(false);
+    const [pdfAvailable, setPdfAvailable] = useState(true);
+
+    useEffect(function () {
+      fetch('Dathunagar%20-%20Typical%20Floor%20Plan.pdf', { method: 'HEAD' })
+        .then(function (res) {
+          if (!res.ok) setPdfAvailable(false);
+        })
+        .catch(function () {
+          setPdfAvailable(false);
+        });
+    }, []);
+
     return React.createElement(
       'div',
       null,
@@ -20,31 +32,30 @@
         'div',
         {
           id: 'floorplan-content',
-          className: 'collapsible-content floorplan-wrapper' + (open ? ' open' : ''),
+          className:
+            'collapsible-content floorplan-wrapper' + (open ? ' open' : ' hidden'),
           role: 'region',
           'aria-label': 'Floor plan'
         },
-        React.createElement(
-          'object',
-          {
-            data: 'floorplan/JGD-Floorplan.pdf',
-            type: 'application/pdf',
-            width: '100%',
-            height: '600px',
-            className: 'floorplan-frame',
-            'aria-label': 'Floor Plan PDF Viewer'
-          },
-          React.createElement(
-            'p',
-            { className: 'pdf-message' },
-            'Unable to display the floor plan. Please use the link below to download the PDF.'
-          )
-        ),
+        pdfAvailable
+          ? React.createElement('object', {
+              data: 'Dathunagar%20-%20Typical%20Floor%20Plan.pdf',
+              type: 'application/pdf',
+              width: '100%',
+              height: '600px',
+              className: 'floorplan-frame',
+              'aria-label': 'Floor Plan PDF Viewer'
+            })
+          : React.createElement(
+              'p',
+              { className: 'pdf-message' },
+              'Unable to display the floor plan. Please use the link below to download the PDF.'
+            ),
         React.createElement(
           'a',
           {
             className: 'download-link',
-            href: 'floorplan/JGD-Floorplan.pdf',
+            href: 'Dathunagar%20-%20Typical%20Floor%20Plan.pdf',
             download: ''
           },
           'Download Floor Plan (PDF)'

--- a/gallery-floorplan.css
+++ b/gallery-floorplan.css
@@ -32,6 +32,10 @@
   opacity: 1;
 }
 
+.hidden {
+  display: none;
+}
+
 .gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -107,6 +111,10 @@
   display: inline-block;
   margin-top: 0.75rem;
   color: #183153;
+}
+
+.pdf-message {
+  margin-top: 0.75rem;
 }
 
 /* Noscript fallback */

--- a/gallery.js
+++ b/gallery.js
@@ -4,7 +4,7 @@
   function Gallery() {
     const [open, setOpen] = useState(false);
     const images = [
-      { src: 'images/building1.jpg', alt: 'Exterior — building elevation', caption: 'Exterior View' },
+      { src: 'building1.jpeg', alt: 'Exterior — building elevation', caption: 'Exterior View' },
       { src: 'hero.jpg', alt: 'Site overview', caption: 'Site Overview' },
       { src: 'building.jpg', alt: 'Street view', caption: 'Street View' }
     ];
@@ -25,7 +25,7 @@
         'div',
         {
           id: 'gallery-content',
-          className: 'collapsible-content' + (open ? ' open' : ''),
+          className: 'collapsible-content' + (open ? ' open' : ' hidden'),
           role: 'region',
           'aria-label': 'Project gallery'
         },

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     <noscript>
       <a href="#gallery-noscript" class="noscript-toggle">View Gallery</a>
       <div id="gallery-noscript" class="gallery-grid">
-        <img src="images/building1.jpg" alt="Exterior — building elevation" width="400" height="300" />
+        <img src="building1.jpeg" alt="Exterior — building elevation" width="400" height="300" />
         <img src="hero.jpg" alt="Site overview" width="400" height="300" />
         <img src="building.jpg" alt="Street view" width="400" height="300" />
       </div>
@@ -91,7 +91,7 @@
     <h2>Floor Plan</h2>
     <div id="floorplan-root"></div>
     <noscript>
-      <a href="floorplan/JGD-Floorplan.pdf">Download Floor Plan (PDF)</a>
+      <a href="Dathunagar%20-%20Typical%20Floor%20Plan.pdf">Download Floor Plan (PDF)</a>
     </noscript>
   </section>
 


### PR DESCRIPTION
## Summary
- Ensure gallery content is hidden by default and revealed through an accessible toggle
- Embed floor plan PDF inline with availability check and user-friendly fallback messaging
- Reuse existing gallery image and floor plan PDF assets instead of duplicating files

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check gallery.js floorplan.js`


------
https://chatgpt.com/codex/tasks/task_e_68a400225e90832cbe823bb15b07b5f2