### PR TITLE
Fix: listings card overlap/clipping and Floor Plan PDF download

### DIFF
--- a/floorplan.js
+++ b/floorplan.js
@@ -48,6 +48,9 @@
               {
                 href: 'floorplan/JGD-Floorplan.pdf',
                 target: '_blank',
+                rel: 'noopener',
+                type: 'application/pdf',
+                download: 'JGD-Floorplan.pdf',
                 className: 'floorplan-link'
               },
               'View Full Floor Plan (PDF)'
@@ -58,12 +61,31 @@
       viewer = React.createElement(
         'div',
         { className: 'floorplan-viewer', role: 'region', 'aria-label': 'Floor Plan Viewer' },
-        React.createElement('object', {
-          data: 'floorplan/JGD-Floorplan.pdf',
-          type: 'application/pdf',
-          'aria-label': 'Floor Plan PDF Viewer',
-          className: 'floorplan-pdf'
-        })
+        React.createElement(
+          'object',
+          {
+            data: 'floorplan/JGD-Floorplan.pdf',
+            type: 'application/pdf',
+            'aria-label': 'Floor Plan PDF Viewer',
+            className: 'floorplan-pdf'
+          },
+          React.createElement(
+            'p',
+            null,
+            'Your browser does not support PDFs. ',
+            React.createElement(
+              'a',
+              {
+                href: 'floorplan/JGD-Floorplan.pdf',
+                target: '_blank',
+                rel: 'noopener',
+                type: 'application/pdf',
+                download: 'JGD-Floorplan.pdf'
+              },
+              'Download PDF'
+            )
+          )
+        )
       );
     } else if (viewerType === 'message') {
       viewer = React.createElement(
@@ -80,7 +102,9 @@
             className: 'floorplan-link',
             href: 'floorplan/JGD-Floorplan.pdf',
             target: '_blank',
-            download: ''
+            rel: 'noopener',
+            type: 'application/pdf',
+            download: 'JGD-Floorplan.pdf'
           },
           'Download Floor Plan (PDF)'
         )

--- a/gallery-floorplan.css
+++ b/gallery-floorplan.css
@@ -122,6 +122,7 @@
   display: inline-block;
   margin-top: 0.75rem;
   color: #183153;
+  pointer-events: auto;
 }
 
 .floorplan-link[aria-disabled='true'] {

--- a/index.html
+++ b/index.html
@@ -91,9 +91,9 @@
     <h2>Floor Plan</h2>
     <div id="floorplan-root"></div>
     <noscript>
-      <a href="Dathunagar%20-%20Typical%20Floor%20Plan.pdf">Download Floor Plan (PDF)</a>
-    </noscript>
-  </section>
+      <a href="floorplan/JGD-Floorplan.pdf" target="_blank" rel="noopener" type="application/pdf" download="JGD-Floorplan.pdf">Download Floor Plan (PDF)</a>
+      </noscript>
+    </section>
 
   <section id="listings" class="section fade-in">
     <h2>Featured Listings</h2>

--- a/style.css
+++ b/style.css
@@ -315,19 +315,24 @@ h3 {
 }
 .img-wrap.brochure img,
 .gallery-brochure img {
+  position: relative;
+  z-index: 0;
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
   filter: grayscale(40%) contrast(1.1) brightness(0.9);
-  transform: scale(1.05);
 }
 .img-brochure-overlay {
   position: absolute;
   inset: 0;
+  z-index: 1;
+  pointer-events: none;
   background: linear-gradient(135deg, rgba(184,134,11,0.6), rgba(34,39,49,0.7));
 }
 .brochure-caption {
   position: absolute;
+  z-index: 2;
   bottom: 16px;
   left: 16px;
   right: 16px;
@@ -338,18 +343,31 @@ h3 {
 }
 .brochure-caption h3 {
   margin: 0;
+  line-height: 1.25;
   font-size: 16px;
   font-weight: 800;
   color: var(--accent-color);
+}
+.listing-card {
+  position: relative;
+  z-index: 0;
+  margin: 0;
+}
+.listing-card + .listing-card {
+  margin-top: 8px;
 }
 .submeta { color: #6b7280; font-size: 12px; }
 .card-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0,1fr));
-  gap: 18px;
+  gap: 24px;
+  row-gap: 24px;
 }
 @media (max-width: 960px) { .card-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } }
-@media (max-width: 640px) { .card-grid { grid-template-columns: 1fr; } }
+@media (max-width: 640px) {
+  .card-grid { grid-template-columns: 1fr; row-gap: 28px; }
+  .listing-card { padding-bottom: 2px; }
+}
 .cta-row { display: flex; gap: 10px; margin-top: 6px; }
 .btn {
   appearance: none;


### PR DESCRIPTION
## Summary
- add robust grid and card styles to prevent listing overlap and heading clipping
- harden floor plan PDF link and embed with iOS-friendly attributes and fallback
- update noscript and layout styles for better mobile spacing and pointer behavior

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65c4fb684832c928a5da3d282ab46