### PR TITLE
Align Floor Plan card with Location layout

### DIFF
--- a/floorplan.js
+++ b/floorplan.js
@@ -1,141 +1,54 @@
-(function () {
-  const { useState, useEffect, useRef } = React;
+(() => {
+  const toggle = document.getElementById('floorplan-toggle');
+  const content = document.getElementById('floorplan-content');
+  const viewer = document.getElementById('floorplan-viewer');
+  if (!toggle || !content || !viewer) return;
 
-  function FloorPlan() {
-    const [open, setOpen] = useState(false);
-    const [hasImage, setHasImage] = useState(null);
-    const [pdfOk, setPdfOk] = useState(null);
-    const tsRef = useRef(Date.now());
-    const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
+  let loaded = false;
+  const imgPath = 'images/floorplan1.png';
+  const pdfPath = 'floorplan/JGD-Floorplan.pdf';
 
-    useEffect(() => {
-      if (!open) return;
-      tsRef.current = Date.now();
+  function showPlaceholder() {
+    viewer.textContent = 'Floor plan will be available soon.';
+  }
 
-      if (hasImage === null) {
-        const img = new Image();
-        img.onload = () => setHasImage(true);
-        img.onerror = () => setHasImage(false);
-        img.src = `images/floorplan1.png?v=${tsRef.current}`;
-      }
-
-      if (pdfOk === null) {
-        fetch(`floorplan/JGD-Floorplan.pdf?v=${tsRef.current}`, { method: 'HEAD' })
-          .then((res) => setPdfOk(res.ok))
-          .catch(() => setPdfOk(false));
-      }
-    }, [open, hasImage, pdfOk]);
-
-    const isMobile = window.matchMedia('(max-width: 640px)').matches;
-
-    let viewer = null;
-    if (isMobile && hasImage === null) {
-      viewer = React.createElement('div', { className: 'fp-skeleton' });
-    } else if (isMobile && hasImage) {
-      viewer = React.createElement('img', {
-        src: `images/floorplan1.png?v=${tsRef.current}`,
-        alt: 'Floor plan preview',
-        decoding: 'async',
-        loading: 'lazy',
-        style: {
-          width: '100%',
-          height: 'auto',
-          borderRadius: '12px',
-          border: '1px solid #ddd',
-          background: '#fff'
-        }
-      });
-    } else if (pdfOk) {
-      viewer = React.createElement(
-        'object',
-        {
-          className: 'floorplan-embed',
-          data: 'floorplan/JGD-Floorplan.pdf#view=FitH',
-          type: 'application/pdf',
-          'aria-label': 'Floor Plan PDF Viewer'
-        },
-        React.createElement('iframe', {
-          className: 'floorplan-embed',
-          src: 'floorplan/JGD-Floorplan.pdf#view=FitH',
-          title: 'Floor Plan PDF Viewer'
+  function loadViewer() {
+    const ts = Date.now();
+    const img = new Image();
+    img.onload = () => {
+      viewer.innerHTML = `<img class="fp-img" src="${imgPath}?v=${ts}" alt="Floor plan preview">`;
+    };
+    img.onerror = () => {
+      fetch(`${pdfPath}?v=${ts}`, { method: 'HEAD' })
+        .then((res) => {
+          if (res.ok) {
+            viewer.innerHTML = `
+<object class="fp-embed" data="${pdfPath}#view=FitH" type="application/pdf">
+  <iframe class="fp-embed" src="${pdfPath}#view=FitH" title="Floor Plan PDF"></iframe>
+</object>`;
+          } else {
+            showPlaceholder();
+          }
         })
-      );
-    }
-
-    if (!viewer && pdfOk === false && (!isMobile || hasImage === false)) {
-      viewer = React.createElement(
-        'p',
-        { className: 'floorplan-message' },
-        'Floor plan file will be available soon.'
-      );
-    }
-
-    return React.createElement(
-      React.Fragment,
-      null,
-      React.createElement(
-        'button',
-        {
-          className: 'collapsible-toggle',
-          'aria-expanded': open,
-          'aria-controls': 'floorplan-content',
-          onClick: () => setOpen(!open)
-        },
-        open ? 'Hide Floor Plan' : 'Show Floor Plan'
-      ),
-      React.createElement(
-        'div',
-        {
-          id: 'floorplan-content',
-          className: 'collapsible-content' + (open ? ' open' : ' hidden')
-        },
-        open
-          ? React.createElement(
-              'div',
-              {
-                className: 'floorplan-card',
-                role: 'region',
-                'aria-label': 'Floor Plan Viewer'
-              },
-              React.createElement(
-                'div',
-                { className: 'floorplan-toolbar' },
-                React.createElement('div', { className: 'fp-title' }, 'Floor Plan'),
-                React.createElement(
-                  'div',
-                  { className: 'fp-actions' },
-                  React.createElement(
-                    'a',
-                    {
-                      className: 'btn btn-ghost',
-                      href: 'floorplan/JGD-Floorplan.pdf',
-                      target: '_blank',
-                      rel: 'noopener'
-                    },
-                    'Open Full PDF'
-                  ),
-                  React.createElement(
-                    'a',
-                    Object.assign(
-                      {
-                        className: 'btn btn-primary',
-                        href: 'floorplan/JGD-Floorplan.pdf'
-                      },
-                      isIOS ? {} : { download: '' }
-                    ),
-                    'Download PDF'
-                  )
-                )
-              ),
-              viewer
-            )
-          : null
-      )
-    );
+        .catch(() => showPlaceholder());
+    };
+    img.src = `${imgPath}?v=${ts}`;
   }
 
-  const root = document.getElementById('floorplan-root');
-  if (root) {
-    ReactDOM.render(React.createElement(FloorPlan), root);
-  }
+  toggle.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    toggle.textContent = expanded ? 'Show Floor Plan' : 'Hide Floor Plan';
+    if (expanded) {
+      content.classList.remove('open');
+      content.classList.add('hidden');
+    } else {
+      content.classList.remove('hidden');
+      content.classList.add('open');
+      if (!loaded) {
+        loadViewer();
+        loaded = true;
+      }
+    }
+  });
 })();

--- a/index.html
+++ b/index.html
@@ -89,11 +89,20 @@
 
   <section id="floorplan" class="section alt fade-in">
     <h2>Floor Plan</h2>
-    <div id="floorplan-root"></div>
+    <button id="floorplan-toggle" class="collapsible-toggle" aria-expanded="false" aria-controls="floorplan-content">Show Floor Plan</button>
+    <div id="floorplan-content" class="collapsible-content hidden">
+      <div class="fp-card" role="region" aria-label="Floor Plan Viewer">
+        <div id="floorplan-viewer" class="fp-box"></div>
+        <div class="fp-actions">
+          <a class="btn btn-ghost" href="floorplan/JGD-Floorplan.pdf" target="_blank" rel="noopener">Open Full PDF</a>
+          <a class="btn btn-primary" href="floorplan/JGD-Floorplan.pdf" download>Download PDF</a>
+        </div>
+      </div>
+    </div>
     <noscript>
       <a href="floorplan/JGD-Floorplan.pdf" target="_blank" rel="noopener" type="application/pdf" download="JGD-Floorplan.pdf">Download Floor Plan (PDF)</a>
-      </noscript>
-    </section>
+    </noscript>
+  </section>
 
   <section id="listings" class="section fade-in">
     <h2>Featured Listings</h2>

--- a/style.css
+++ b/style.css
@@ -542,3 +542,61 @@ h3 {
   }
 }
 
+/* Floor Plan card and viewer */
+#floorplan.section {
+  max-width: 960px;
+}
+
+.fp-card {
+  background: #f8f9fb;
+  border: 1px solid #e6e6e6;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.fp-box {
+  max-width: 1200px;
+  margin: 0 auto;
+  height: 420px;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  overflow: hidden;
+  background: #fff;
+}
+
+.fp-img,
+.fp-embed {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.fp-img {
+  object-fit: contain;
+}
+
+.fp-actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.fp-actions a:focus-visible {
+  outline: 3px solid #ffd166;
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .fp-box {
+    height: 300px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Replace React floor-plan component with vanilla JS toggle that loads an image preview or PDF fallback
- Introduce fp-card, fp-box, and fp-actions markup and styles for a centered card matching Location section
- Ensure viewer shows preview image without scrollbars and always offers open/download PDF links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a809b7393c832c889b40cab2622224