### PR TITLE
Fix desktop floor plan dropdown

### DIFF
--- a/floorplan.js
+++ b/floorplan.js
@@ -1,54 +1,69 @@
 (() => {
-  const toggle = document.getElementById('floorplan-toggle');
-  const content = document.getElementById('floorplan-content');
-  const viewer = document.getElementById('floorplan-viewer');
-  if (!toggle || !content || !viewer) return;
+  let initialized = false;
+  document.addEventListener('DOMContentLoaded', () => {
+    if (initialized) return;
+    initialized = true;
 
-  let loaded = false;
-  const imgPath = 'images/floorplan1.png';
-  const pdfPath = 'floorplan/JGD-Floorplan.pdf';
+    const btn = document.getElementById('floorplan-toggle');
+    const content = document.getElementById('floorplan-content');
+    const viewer = document.getElementById('floorplan-viewer');
+    if (!btn || !content || !viewer) {
+      console.warn('Floor plan: required elements not found');
+      return;
+    }
 
-  function showPlaceholder() {
-    viewer.textContent = 'Floor plan will be available soon.';
-  }
+    const pdfPath = 'floorplan/JGD-Floorplan.pdf';
+    const imgPath = 'images/floorplan1.png';
+    const downloadLink = content.querySelector('.btn-primary');
 
-  function loadViewer() {
-    const ts = Date.now();
-    const img = new Image();
-    img.onload = () => {
-      viewer.innerHTML = `<img class="fp-img" src="${imgPath}?v=${ts}" alt="Floor plan preview">`;
-    };
-    img.onerror = () => {
-      fetch(`${pdfPath}?v=${ts}`, { method: 'HEAD' })
-        .then((res) => {
-          if (res.ok) {
-            viewer.innerHTML = `
-<object class="fp-embed" data="${pdfPath}#view=FitH" type="application/pdf">
-  <iframe class="fp-embed" src="${pdfPath}#view=FitH" title="Floor Plan PDF"></iframe>
+    function showPlaceholder() {
+      viewer.textContent = 'Floor plan will be available soon.';
+      if (downloadLink) {
+        downloadLink.setAttribute('aria-disabled', 'true');
+        downloadLink.addEventListener('click', (e) => e.preventDefault());
+      }
+    }
+
+    function buildViewer() {
+      const ts = Date.now();
+      const img = new Image();
+      img.onload = () => {
+        viewer.innerHTML = '';
+        const el = document.createElement('img');
+        el.className = 'fp-img';
+        el.src = `${imgPath}?v=${ts}`;
+        el.alt = 'Floor plan preview';
+        viewer.appendChild(el);
+      };
+      img.onerror = () => {
+        fetch(`${pdfPath}?v=${ts}`, { method: 'HEAD' })
+          .then((res) => {
+            if (res.ok) {
+              viewer.innerHTML = `
+<object class="fp-embed" type="application/pdf" data="${pdfPath}#view=FitH">
+  <iframe class="fp-embed" src="${pdfPath}#view=FitH" title="Floor Plan PDF Viewer"></iframe>
 </object>`;
-          } else {
-            showPlaceholder();
-          }
-        })
-        .catch(() => showPlaceholder());
-    };
-    img.src = `${imgPath}?v=${ts}`;
-  }
+            } else {
+              showPlaceholder();
+            }
+          })
+          .catch(() => showPlaceholder());
+      };
+      img.src = `${imgPath}?v=${ts}`;
+    }
 
-  toggle.addEventListener('click', () => {
-    const expanded = toggle.getAttribute('aria-expanded') === 'true';
-    toggle.setAttribute('aria-expanded', String(!expanded));
-    toggle.textContent = expanded ? 'Show Floor Plan' : 'Hide Floor Plan';
-    if (expanded) {
-      content.classList.remove('open');
-      content.classList.add('hidden');
-    } else {
-      content.classList.remove('hidden');
-      content.classList.add('open');
-      if (!loaded) {
-        loadViewer();
+    let loaded = false;
+    function onToggle() {
+      const isOpen = content.classList.toggle('is-open');
+      btn.setAttribute('aria-expanded', String(isOpen));
+      btn.textContent = isOpen ? 'Hide Floor Plan' : 'Show Floor Plan';
+      if (isOpen && !loaded) {
+        buildViewer();
         loaded = true;
       }
     }
+
+    btn.removeEventListener('click', onToggle);
+    btn.addEventListener('click', onToggle);
   });
 })();

--- a/gallery-floorplan.css
+++ b/gallery-floorplan.css
@@ -27,7 +27,7 @@
   transition: max-height 0.4s ease, opacity 0.4s ease;
 }
 
-.collapsible-content.open {
+.collapsible-content.is-open {
   max-height: 2000px;
   opacity: 1;
 }

--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 1000;
+  pointer-events: auto;
 }
 .nav-container {
   max-width: 960px;
@@ -572,6 +573,7 @@ h3 {
 .fp-embed {
   width: 100%;
   height: 100%;
+  display: block;
   border: 0;
   border-radius: 12px;
   background: #fff;
@@ -598,5 +600,12 @@ h3 {
   .fp-box {
     height: 300px;
   }
+}
+
+.hidden { display: none !important; }
+.is-open { display: block !important; }
+
+@media (min-width: 1024px) {
+  .fp-box { height: clamp(480px, 70vh, 860px); }
 }
 


### PR DESCRIPTION
## Summary
- Harden floor plan toggle to build viewer once and show/hide using `.is-open`
- Prefer cached image with PDF fallback and disable download link if missing
- Add visibility helpers and desktop viewer sizing; ensure nav doesn't block clicks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a80fb9b7dc832cad38ec076289861a