### PR TITLE
Fix gallery toggle class for Gallery button

### DIFF
--- a/gallery.js
+++ b/gallery.js
@@ -23,12 +23,12 @@
       ),
       React.createElement(
         'div',
-        {
-          id: 'gallery-content',
-          className: 'collapsible-content' + (open ? ' open' : ' hidden'),
-          role: 'region',
-          'aria-label': 'Project gallery'
-        },
+          {
+            id: 'gallery-content',
+            className: 'collapsible-content' + (open ? ' is-open' : ' hidden'),
+            role: 'region',
+            'aria-label': 'Project gallery'
+          },
         React.createElement(
           'div',
           { className: 'gallery-grid' },


### PR DESCRIPTION
## Summary
- Correct gallery toggle logic to use `is-open` class so the gallery button reveals images properly

## Testing
- `node --check gallery.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96f8d308832ca90690d434b73a7c