### PR TITLE
Redirect lead form submissions to WhatsApp

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,10 @@ if (leadForm) {
       phone: leadForm.phone.value,
       message: leadForm.message.value
     };
+    const msg = encodeURIComponent(
+      `Name: ${data.from_name}\nEmail: ${data.from_email}\nPhone: ${data.phone}\nMessage: ${data.message}`
+    );
+    window.location.href = `https://wa.me/917013991990?text=${msg}`;
     emailjs.send('YOUR_SERVICE_ID', 'YOUR_LEAD_TEMPLATE_ID', data)
       .then(() => {
         alert('Thank you for contacting us!');


### PR DESCRIPTION
## Summary
- Redirect lead form submissions to WhatsApp using an encoded message built from form data.
- Preserve EmailJS lead emails so enquiries arrive via both WhatsApp and email.
- Update WhatsApp destination to `917013991990` and redirect in the same window.

## Testing
- `node --check app.js && echo 'syntax ok'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9a86a844832ca2089714592ea43a