### PR TITLE
Replace enquiry form with WhatsApp links

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,29 +12,29 @@ const observer = new IntersectionObserver((entries) => {
 
 document.querySelectorAll('.fade-in').forEach((el) => observer.observe(el));
 
-// Lead capture form using EmailJS
-const leadForm = document.getElementById('lead-form');
-if (leadForm) {
-  leadForm.addEventListener('submit', (e) => {
-    e.preventDefault();
-    const data = {
-      from_name: leadForm.name.value,
-      from_email: leadForm.email.value,
-      phone: leadForm.phone.value,
-      message: leadForm.message.value
-    };
-    const msg = encodeURIComponent(
-      `Name: ${data.from_name}\nEmail: ${data.from_email}\nPhone: ${data.phone}\nMessage: ${data.message}`
-    );
-    window.location.href = `https://wa.me/917013991990?text=${msg}`;
-    emailjs.send('YOUR_SERVICE_ID', 'YOUR_LEAD_TEMPLATE_ID', data)
-      .then(() => {
-        alert('Thank you for contacting us!');
-        leadForm.reset();
-      })
-      .catch((err) => {
-        console.error('Lead capture failed', err);
-        alert('Failed to send. Please try again later.');
-      });
-  });
-}
+// Lead capture form using EmailJS (disabled)
+// const leadForm = document.getElementById('lead-form');
+// if (leadForm) {
+//   leadForm.addEventListener('submit', (e) => {
+//     e.preventDefault();
+//     const data = {
+//       from_name: leadForm.name.value,
+//       from_email: leadForm.email.value,
+//       phone: leadForm.phone.value,
+//       message: leadForm.message.value
+//     };
+//     const msg = encodeURIComponent(
+//       `Name: ${data.from_name}\nEmail: ${data.from_email}\nPhone: ${data.phone}\nMessage: ${data.message}`
+//     );
+//     window.location.href = `https://wa.me/917013991990?text=${msg}`;
+//     emailjs.send('YOUR_SERVICE_ID', 'YOUR_LEAD_TEMPLATE_ID', data)
+//       .then(() => {
+//         alert('Thank you for contacting us!');
+//         leadForm.reset();
+//       })
+//       .catch((err) => {
+//         console.error('Lead capture failed', err);
+//         alert('Failed to send. Please try again later.');
+//       });
+//   });
+// }

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <li><a href="#gallery">Gallery</a></li>
         <li><a href="#listings">Listings</a></li>
         <li><a href="#location">Location</a></li>
-        <li><a href="#enquire">Enquire</a></li>
+        <li><a href="https://wa.me/917013991990" target="_blank" rel="noopener">Enquire</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
     </div>
@@ -120,13 +120,7 @@
 
   <section id="enquire" class="section fade-in">
     <h2>Enquire Now</h2>
-    <form id="lead-form" class="lead-form">
-      <input type="text" name="name" placeholder="Your Name" required />
-      <input type="email" name="email" placeholder="Email" required />
-      <input type="tel" name="phone" placeholder="Phone Number" required />
-      <textarea name="message" placeholder="Message" required></textarea>
-      <button type="submit">Submit</button>
-    </form>
+    <a class="btn" href="https://wa.me/917013991990" target="_blank" rel="noopener">Chat on WhatsApp</a>
   </section>
 
   <section id="contact" class="section fade-in">

--- a/listings.js
+++ b/listings.js
@@ -14,7 +14,7 @@
       tower: "Block A",
       floor: 3,
       facing: "East",
-      link: "#enquire"
+      link: "https://wa.me/917013991990"
     },
     {
       id: 2,
@@ -27,7 +27,7 @@
       tower: "Block B",
       floor: 5,
       facing: "North-East",
-      link: "#enquire"
+      link: "https://wa.me/917013991990"
     }
   ];
 
@@ -47,7 +47,7 @@
       e("div", { className: "card-body" },
         e("div", { className: "submeta" }, `${item.tower} • Floor ${item.floor} • ${item.facing} facing`),
         e("div", { className: "cta-row" },
-          e("a", { className: "btn btn-primary", href: item.link }, "Enquire"),
+          e("a", { className: "btn btn-primary", href: item.link, target: "_blank", rel: "noopener" }, "Enquire"),
           e("button", { className: "btn btn-ghost", onClick: () => share(item) },
             e("i", { className: "fa-solid fa-share-nodes" }), " Share")
         )


### PR DESCRIPTION
## Summary
- Replace site-wide enquiry references with direct WhatsApp contact links.
- Update listing cards to open WhatsApp chat instead of the internal form.
- Disable obsolete lead capture logic.

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ac9dc7c258832cbae5955fdbccf0a8